### PR TITLE
Travis will perform a shallow clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: generic
 
+git:
+  depth: 1
+
 matrix:
   include:
     - name: Website


### PR DESCRIPTION
Default depth of git clone in travis is 50. Reduced it to 1.