### PR TITLE
Updated github links

### DIFF
--- a/src/features.rst
+++ b/src/features.rst
@@ -42,7 +42,7 @@ Degree Distribution
 ^^^^^^^^^^^^^^^^^^^
 Empirically observed complex networks tend to show a heavy tailed degree distribution which follow a power-law with a characteristic exponent. NetworKit provides functions to analyze the
 degree distribution of a network. For details visit the
-`Degree Distribution <https://github.com/kit-parco/networkit/blob/Dev/notebooks/User-Guide.ipynb>`_ Section of the User Guide. The algorithm runs in :math:`O(n)`.
+`Degree Distribution <https://github.com/networkit/networkit/blob/Dev/notebooks/User-Guide.ipynb>`_ Section of the User Guide. The algorithm runs in :math:`O(n)`.
 
 (Degree) Assortativity
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -62,17 +62,17 @@ Clustering Coefficients
 
 Clustering coefficients are key figures for the amount of transitivity in networks. NetworKit provides functions for both the global clustering coefficient as well as the local clustering
 coefficient. NetworKit implements the wedge sampling approximation algorithm. It runs in essentially linear or even constant time, depending on the respective measure. For details on the
-usage visit the `Clustering Coefficient <https://github.com/kit-parco/networkit/blob/Dev/notebooks/User-Guide.ipynb>`_
+usage visit the `Clustering Coefficient <https://github.com/networkit/networkit/blob/Dev/notebooks/User-Guide.ipynb>`_
 Section of the User Guide.
 
 Components and Cores
 ^^^^^^^^^^^^^^^^^^^^
 
 We compute connected components in linear time using a parallel label propagation scheme in which each node adopts the maximum label in its neighborhood. Take a look at
-the `Connected Components <https://github.com/kit-parco/networkit/blob/Dev/notebooks/User-Guide.ipynb>`_ Section in the User Guide.
+the `Connected Components <https://github.com/networkit/networkit/blob/Dev/notebooks/User-Guide.ipynb>`_ Section in the User Guide.
 
 The core decomposition algorithm implemented in NetworKit uses a bucket data structure for managing remaining node degrees and has a running time which is linear
-in the number of edges. Visit the `Core Decomposition <https://github.com/kit-parco/networkit/blob/Dev/notebooks/User-Guide.ipynb>`_
+in the number of edges. Visit the `Core Decomposition <https://github.com/networkit/networkit/blob/Dev/notebooks/User-Guide.ipynb>`_
 Section of the User Guide for usage details.
 
 Centrality

--- a/src/get_started.rst
+++ b/src/get_started.rst
@@ -15,7 +15,7 @@ Although the standard Python interpreter works fine, we recommend `IPython <http
 workflows. View the `IPython Quickstart Guide`_ for installation instructions and how to use NetworKit with IPython.
 
 Once you have installed NetworKit, please make sure to check out our
-`NetworKit UserGuide <https://github.com/kit-parco/networkit/blob/Dev/notebooks/User-Guide.ipynb>`_ for an overview of the features provided
+`NetworKit UserGuide <https://github.com/networkit/networkit/blob/Dev/notebooks/User-Guide.ipynb>`_ for an overview of the features provided
 in NetworKit.
 
 |separator|
@@ -115,9 +115,9 @@ There is currently no official support for Windows 8 and below.
 Build NetworKit from Source
 ===========================
 
-You can clone NetworKit from `GitHub <https://github.com/kit-parco/networkit>`_ with git or download the source code as a `zip file <https://github.com/kit-parco/networkit/archive/master.zip>`_.
+You can clone NetworKit from `GitHub <https://github.com/networkit/networkit>`_ with git or download the source code as a `zip file <https://github.com/networkit/networkit/archive/master.zip>`_.
 
-For further information, we refer to the `README file <https://github.com/kit-parco/networkit#installation-instructions>`_ of our GitHub repository, which contains instructions for building NetworKit from source.
+For further information, we refer to the `README file <https://github.com/networkit/networkit#installation-instructions>`_ of our GitHub repository, which contains instructions for building NetworKit from source.
 
 |separator|
 
@@ -142,7 +142,7 @@ If you want to use NetworKit in the IPython terminal, type the following command
 	from networkit import *
 
 The first line opens the IPython terminal. The second line imports the *networkit* Python module. After that, you should be able to use NetworKit interactively.
-For usage examples, refer to the `NetworKit UserGuide <https://github.com/kit-parco/networkit/blob/Dev/notebooks/User-Guide.ipynb>`_.
+For usage examples, refer to the `NetworKit UserGuide <https://github.com/networkit/networkit/blob/Dev/notebooks/User-Guide.ipynb>`_.
 
 IPython Notebook/Jupyter
 ------------------------

--- a/src/index.rst
+++ b/src/index.rst
@@ -17,7 +17,7 @@
         </div>
         <div class="Downloads" style="display: table-cell; width: 33.33%; padding-left: 30px">
           <div>Clone from GitHub</div>
-          <span style="display: block;overflow: hidden;"><input onClick="this.setSelectionRange(0, this.value.length)" style="width: 100%" type="text" value="git clone https://github.com/kit-parco/networkit.git" readonly=""/></span>
+          <span style="display: block;overflow: hidden;"><input onClick="this.setSelectionRange(0, this.value.length)" style="width: 100%" type="text" value="git clone https://github.com/networkit/networkit.git" readonly=""/></span>
 
           <div style="padding-top: 15px">Install via pip3</div>
           <span style="display: block;overflow: hidden;"><input onClick="this.setSelectionRange(0, this.value.length)" style="width: 100%" type="text" value="pip3 install networkit" readonly=""/></span>
@@ -32,7 +32,7 @@
 
           <div style="padding-top: 15px">View the <a href="https://sympa.cms.hu-berlin.de/sympa/arc/networkit">mailing list archive</a></div>
 
-          <div style="padding-top: 15px"><a href="https://github.com/kit-parco/networkit/blob/Dev/notebooks/User-Guide.ipynb">NetworKit User Guide</a></div>
+          <div style="padding-top: 15px"><a href="https://github.com/networkit/networkit/blob/Dev/notebooks/User-Guide.ipynb">NetworKit User Guide</a></div>
 
         </div>
       </div>

--- a/src/news.rst
+++ b/src/news.rst
@@ -55,7 +55,7 @@ Minor changes:
 - All algorithms for finding the top-k (harmonic) closeness can also return all the nodes whose centrality is equal to the k-th highest. This behaviour can be triggered by parameter passed in the constructor of the class.
 - Faster KONECT and SNAP graph readers: roughly 2x speedup on the previous readers.
 - Greatly improved running time of NetworKit’s unit tests.
-- Size reduction of the “input” folder. In case of space constraints, we suggest to do a shallow clone of the NetworKit repository: git clone --depth=1 http://github.com/kit-parco/networkit
+- Size reduction of the “input” folder. In case of space constraints, we suggest to do a shallow clone of the NetworKit repository: git clone --depth=1 http://github.com/networkit/networkit
 
 
 December 14, 2017: **NetworKit 4.5 released**
@@ -76,7 +76,7 @@ Minor:
 - Dynamic algorithm for updating the weakly connected components of a directed graph after edge additions or removals.
 - Official support for Windows 10. Take a look at the `Get Started guide <https://networkit.github.io/get_started.html>`_ for further instructions.
 - Support for SCons3. There are no more dependencies on Python 2 if you decide to use SCons3 with Python 3.
-- Improved include of external libraries. These can now simply be specified in the build.conf file. See `Pull Request #58 <https://github.com/kit-parco/networkit/pull/58>`_ for further details.
+- Improved include of external libraries. These can now simply be specified in the build.conf file. See `Pull Request #58 <https://github.com/networkit/networkit/pull/58>`_ for further details.
 
 
 September 06, 2017: **NetworKit 4.4 released**
@@ -147,7 +147,7 @@ February 25, 2017: **Migration to GitHub**
 The NetworKit team is happy to announce that the NetworKit project has been successfully migrated to GitHub. Please join
 us on
 
-https://github.com/kit-parco/networkit
+https://github.com/networkit/networkit
 
 We believe the migration will make it easier for developers to contribute to the project and we hope to bring the advantages of efficient large-scale network analysis to even more people.
 

--- a/style/_templates/home_navbar.html
+++ b/style/_templates/home_navbar.html
@@ -57,7 +57,7 @@
       <h1>NetworKit</h1>
       <h3>Large-Scale Network Analysis &#8212; Interactive and Fast!</h3>
       <a class="customButton" href="{{ pathto('get_started') }}">Get Started</a>
-      <a class="customButton" href="https://github.com/kit-parco/networkit/blob/Dev/notebooks/User-Guide.ipynb">User Guide</a>
+      <a class="customButton" href="https://github.com/networkit/networkit/blob/Dev/notebooks/User-Guide.ipynb">User Guide</a>
     </div>
 
   </div>

--- a/style/_templates/layout.html
+++ b/style/_templates/layout.html
@@ -9,7 +9,7 @@
 {# Add github banner (from: https://github.com/blog/273-github-ribbons). #}
 {% block header %}
   {{ super() }}
-  <a href="https://github.com/kit-parco/networkit"
+  <a href="https://github.com/networkit/networkit"
      class="visible-desktop hidden-xs"><img style="position: absolute; width:auto; height: auto; max-width: 200px; top:
      0px; right: 0; border: 0; z-index: 3;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png" alt="Fork me on GitHub"></a>  
 {% endblock %}


### PR DESCRIPTION
Update links after networkit migrated to https://github.com/networkit/networkit on github.