### PR TITLE
Updates jquery + Fix for dead link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,5 +3,10 @@ project(networkit-website NONE)
 
 add_custom_target(website ALL
 		COMMAND rm -rf www
-		COMMAND sphinx-build ${CMAKE_SOURCE_DIR}/src www)
+		COMMAND sphinx-build ${CMAKE_SOURCE_DIR}/src www
+		COMMAND rm -rf www/_static/js/jquery-*
+		COMMAND rm -rf www/_static/bootstrap-sphinx.js)
 
+# The last two commands remove any jquery-versions and files incompatible with newer jquery from sphinx-bootstrap-theme
+# For "jquery-*" the internal sphinx-version is used (_static/jquery.js). "bootstrap-sphinx.js" is replaced by a custom version
+# based on code from https://github.com/ryan-roemer/sphinx-bootstrap-theme/blob/master/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js_t

--- a/src/conf.py
+++ b/src/conf.py
@@ -12,8 +12,6 @@
 
 import sys, os, inspect
 import sphinx_bootstrap_theme
-#import matplotlib as mpl
-#mpl.use("Agg")
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/style/_static/custom-bootstrap-sphinx.js
+++ b/style/_static/custom-bootstrap-sphinx.js
@@ -1,0 +1,148 @@
+/**
+ * This based on code from https://github.com/ryan-roemer/sphinx-bootstrap-theme/blob/master/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js_t
+ * Modified to work with jquery >= 3.0
+ */
+
+(function ($) {
+    /**
+     * Patch TOC list.
+     *
+     * Will mutate the underlying span to have a correct ul for nav.
+     *
+     * @param $span: Span containing nested UL"s to mutate.
+     * @param minLevel: Starting level for nested lists. (1: global, 2: local).
+     */
+    var patchToc = function ($ul, minLevel) {
+      var findA,
+        patchTables,
+        $localLi;
+  
+      // Find all a "internal" tags, traversing recursively.
+      findA = function ($elem, level) {
+        level = level || 0;
+        var $items = $elem.find("> li > a.internal, > ul, > li > ul");
+  
+        // Iterate everything in order.
+        $items.each(function (index, item) {
+          var $item = $(item),
+            tag = item.tagName.toLowerCase(),
+            $childrenLi = $item.children("li"),
+            $parentLi = $($item.parent("li"), $item.parent().parent("li"));
+  
+          // Add dropdowns if more children and above minimum level.
+          if (tag === "ul" && level >= minLevel && $childrenLi.length > 0) {
+            $parentLi
+              .addClass("dropdown-submenu")
+              .children("a").first().attr("tabindex", -1);
+  
+            $item.addClass("dropdown-menu");
+          }
+  
+          findA($item, level + 1);
+        });
+      };
+  
+      findA($ul);
+    };
+  
+    /**
+     * Patch all tables to remove ``docutils`` class and add Bootstrap base
+     * ``table`` class.
+     */
+    patchTables = function () {
+      $("table.docutils")
+        .removeClass("docutils")
+        .addClass("table")
+        .attr("border", 0);
+    };
+  
+    $(window).on('load', function () {
+      /*
+       * Scroll the window to avoid the topnav bar
+       * https://github.com/twbs/bootstrap/issues/1768
+       */
+      if ($("#navbar.navbar-fixed-top").length > 0) {
+        var navHeight = $("#navbar").height(),
+          shiftWindow = function() { scrollBy(0, -navHeight - 10); };
+  
+        if (location.hash) {
+          setTimeout(shiftWindow, 1);
+        }
+  
+        window.addEventListener("hashchange", shiftWindow);
+      }
+    });
+  
+    $(document).ready( function () {
+      // Add styling, structure to TOC"s.
+      $(".dropdown-menu").each(function () {
+        $(this).find("ul").each(function (index, item){
+          var $item = $(item);
+          $item.addClass("unstyled");
+        });
+      });
+  
+      // Global TOC.
+      if ($("ul.globaltoc li").length) {
+        patchToc($("ul.globaltoc"), 1);
+      } else {
+        // Remove Global TOC.
+        $(".globaltoc-container").remove();
+      }
+  
+      // Local TOC.
+      $(".bs-sidenav ul").addClass("nav nav-list");
+      $(".bs-sidenav > ul > li > a").addClass("nav-header");
+  
+      // Local TOC.
+      patchToc($("ul.localtoc"), 2);
+  
+      // Mutate sub-lists (for bs-2.3.0).
+      $(".dropdown-menu ul").not(".dropdown-menu").each(function () {
+        var $ul = $(this),
+          $parent = $ul.parent(),
+          tag = $parent[0].tagName.toLowerCase(),
+          $kids = $ul.children().detach();
+  
+        // Replace list with items if submenu header.
+        if (tag === "ul") {
+          $ul.replaceWith($kids);
+        } else if (tag === "li") {
+          // Insert into previous list.
+          $parent.after($kids);
+          $ul.remove();
+        }
+      });
+  
+      // Add divider in page TOC.
+      $localLi = $("ul.localtoc li");
+      if ($localLi.length > 2) {
+        $localLi.first().after("<li class=\"divider\"></li>");
+      }
+  
+      // Patch tables.
+      patchTables();
+  
+      // Add Note, Warning styles. (BS v2,3 compatible).
+      $(".admonition").addClass("alert alert-info")
+        .filter(".warning, .caution")
+          .removeClass("alert-info")
+          .addClass("alert-warning").end()
+        .filter(".error, .danger")
+          .removeClass("alert-info")
+          .addClass("alert-danger alert-error").end();
+  
+      // Inline code styles to Bootstrap style.
+      $("tt.docutils.literal").not(".xref").each(function (i, e) {
+        // ignore references
+        if (!$(e).parent().hasClass("reference")) {
+          $(e).replaceWith(function () {
+            return $("<code />").html($(this).html());
+          });
+        }});
+  
+      // Update sourcelink to remove outerdiv (fixes appearance in navbar).
+      var $srcLink = $(".nav #sourcelink");
+      $srcLink.parent().html($srcLink.html());
+    });
+  }(window.$ || window.jQuery));

--- a/style/_static/publications.js
+++ b/style/_static/publications.js
@@ -1,14 +1,14 @@
 $(document).ready(function () {
         $(".btn-link").click(function () {
-        	var btn = $jqTheme(this);
+        	var btn = $(this);
         	$(".collapse").each(function( index ) {
-        		if (btn.parent().text() === $jqTheme(this).parent().text()) {
+        		if (btn.parent().text() === $(this).parent().text()) {
         			if(btn.hasClass("collapsed")) {
 	        			btn.removeClass("collapsed");
-    	    			$jqTheme(this).collapse('show');        				
+    	    			$(this).collapse('show');        				
         			} else {
         				btn.addClass("collapsed");
-        				$jqTheme(this).collapse('hide');
+        				$(this).collapse('hide');
         			}
 
         		}

--- a/style/_templates/home_navbar.html
+++ b/style/_templates/home_navbar.html
@@ -56,7 +56,7 @@
     <div class="welcome-index" style="text-align: center; padding-top: 30px; padding-bottom: 10px;">
       <img class="logo-index" src="_static/logo_bw_inv.png"><br><p style="margin: 10px"></p>
       <a class="customButton" href="{{ pathto('get_started') }}">Get Started</a>
-      <a class="customButton" href="https://github.com/networkit/networkit/blob/Dev/notebooks/User-Guide.ipynb">User Guide</a>
+      <a class="customButton" href="https://networkit.github.io/dev-docs/notebooks/User-Guide.html">User Guide</a>
     </div>
 
   </div>

--- a/style/_templates/layout.html
+++ b/style/_templates/layout.html
@@ -14,6 +14,15 @@
      0px; right: 0; border: 0; z-index: 3;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png" alt="Fork me on GitHub"></a>  
 {% endblock %}
 
+{%- block extrahead %}
+<meta charset='utf-8'>
+<meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1'>
+<meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1'>
+<meta name="apple-mobile-web-app-capable" content="yes">
+<script type="text/javascript" src="{{ pathto('_static', 1) + '/bootstrap-' + bootstrap_version + '/js/bootstrap.min.js' }} "></script>
+<script type="text/javascript" src="{{ pathto('_static/custom-bootstrap-sphinx.js', 1) }} "></script>
+{% endblock %}
+
 
 {% macro customNavBar() %}
   {% if pagename == 'index' %}


### PR DESCRIPTION
This PR includes the following:

- sphinx-bootstrap-theme: remove includes for jquery-files due to security issues with versions lower then 3.5 (bootstrap-theme uses 1.11)
- sphinx-bootstrap-theme: adding a modified `bootstrap-sphinx.js` to be compatible with jQuery 3.5
- sphinx-bootstrap-theme: removes now unused files from sphinx-bootstrap-theme from final build
- Changes dead link to User-Guide from index-page
- Modify javascript for "Publications" to use sphinx-internal jquery instead of sphinx-bootstrap-theme
